### PR TITLE
Add `startSourceSpan` and `endSourceSpan` to `BlockParameter`

### DIFF
--- a/packages/compiler/src/ml_parser/ast.ts
+++ b/packages/compiler/src/ml_parser/ast.ts
@@ -138,6 +138,8 @@ export class BlockParameter implements BaseNode {
   }
 
   readonly type = 'blockParameter';
+  readonly startSourceSpan: null = null;
+  readonly endSourceSpan: null = null;
 }
 
 export interface Visitor {


### PR DESCRIPTION
Adds `startSourceSpan` and `endSourceSpan` to `BlockParameter` to fix type check error in https://github.com/prettier/prettier/pull/15569