### PR TITLE
feat: parse ICU expressions if also parsing block syntax

### DIFF
--- a/packages/angular-html-parser/src/index.ts
+++ b/packages/angular-html-parser/src/index.ts
@@ -62,7 +62,7 @@ export function parse(
     input,
     "angular-html-parser",
     {
-      tokenizeExpansionForms: false,
+      tokenizeExpansionForms: tokenizeAngularBlocks,
       interpolationConfig: undefined,
       canSelfClose,
       allowHtmComponentClosingTags,


### PR DESCRIPTION
BREAKING CHANGE: ICU expressions are now parsed if also parsing block syntax. Previously this would throw a parse error when trying to parse an ICU expression.

This is needed to fix https://github.com/prettier/prettier/issues/15650

A corresponding prettier PR in prettier will be needed to handle this change: https://github.com/prettier/prettier/pull/15773